### PR TITLE
Replace deprecated bp_core_is_multisite() for is_multisite()

### DIFF
--- a/bp-include-non-member-comments-bp-functions.php
+++ b/bp-include-non-member-comments-bp-functions.php
@@ -29,7 +29,7 @@ function bp_blogs_record_nonmember_comment( $comment_id, $is_approved ) {
 	if ( !empty( $post->post_password ) )
 		return false;
 
-	if ( (int)get_blog_option( $recorded_comment->blog_id, 'blog_public' ) || !bp_core_is_multisite() ) {
+	if ( (int)get_blog_option( $recorded_comment->blog_id, 'blog_public' ) || ! is_multisite() ) {
 		/* Record in activity streams */
 		$comment_link = get_permalink( $comment->comment_post_ID ) . '#comment-' . $comment_id;
 		


### PR DESCRIPTION
Hi Boone,

This PR fixes a fatal error since `bp_core_is_multisite()` is deprecated since BuddyPress v1.5 and isn't automatically loaded for newer versions of BuddyPress.